### PR TITLE
A few changes to catch gem upto current api endpoints

### DIFF
--- a/lib/shiphawk/api/query_helpers.rb
+++ b/lib/shiphawk/api/query_helpers.rb
@@ -31,7 +31,7 @@ module Shiphawk
         "shipments/#{sub_path}"
       end
 
-      def status_path id
+      def status_path
         shipments_path "status"
       end
 

--- a/lib/shiphawk/api/shipments.rb
+++ b/lib/shiphawk/api/shipments.rb
@@ -34,7 +34,7 @@ module Shiphawk
       end
 
       def shipments_destroy shipment_id
-        delete_request shipments_path, id: shipment_id
+        delete_request shipments_path(shipment_id), {}
       end
 
     end

--- a/lib/shiphawk/api/shipments_status.rb
+++ b/lib/shiphawk/api/shipments_status.rb
@@ -9,8 +9,8 @@ module Shiphawk
     #
     module ShipmentsStatus
 
-      def shipments_status_update shipment_id, options
-        put_request status_path(shipment_id), options
+      def shipments_status_update options
+        put_request status_path, options
       end
 
     end


### PR DESCRIPTION
Delete takes the id of the shipment as part of the path.
Not as an `id` param

the multi-updating shipment_status_update endpoint does not need a shipment id passed to it.
