### PR TITLE
The request method returns the body of the response instead of the fa…

### DIFF
--- a/lib/shiphawk/helpers/request.rb
+++ b/lib/shiphawk/helpers/request.rb
@@ -21,7 +21,7 @@ module Shiphawk
           conn = get_connection
           response = conn.send(verb, "#{API_PATH}#{api_version}/#{endpoint}", params)
           raise_errors response
-          response
+          response.body
         end
       end
 


### PR DESCRIPTION
…raday object.

We found this easier to use in our environment. Open to feedback however.
The previous gem used this technique I believe.
